### PR TITLE
Add Tiercel to Swift networking

### DIFF
--- a/Swift.md
+++ b/Swift.md
@@ -255,6 +255,7 @@ A curated list of iOS objective-C ecosystem.
 * [RxAlamofire.swift](https://github.com/RxSwiftCommunity/RxAlamofire) - 为Alamofire提供函数响应式（FRP）调用接口,以优雅的方式使用Alamofire进行网络请求。
 * [socket.io-client-swift](https://github.com/socketio/socket.io-client-swift) - WebSockect 客户端类库。开放的通讯协议，有利于构建强大地跨平台应用。
 * [Transporter](https://github.com/nghialv/Transporter) - swift， 短小、精悍、易用的多文件（并发或顺序）上传和下载传输库。还支持后台运行、传输进程跟踪、暂停/续传/取消/重试控制等功能。
+* [Tiercel](https://github.com/Danie1s/Tiercel) - 纯 Swift iOS 下载框架，支持后台下载、断点续传、应用重启恢复与任务管理。
 * [Just](https://github.com/JustHTTP/Just) - 小而美的 HTTP 类。功能简单、直接、完整且健壮性高-- swift。
 * [Future](https://github.com/nghialv/Future) - 基于微框架设计思想的异步执行及结果响应类，代码即简单又干净-- swift。
 * [HFDownLoad](https://github.com/hongfenglt/HFDownLoad) - iOS开发网络篇之文件下载、大文件下载、断点下载:NSData方式、NSURLConnection方式、NSURLSession下载方式 [下载方式具体的思路、区别见Blog](http://blog.csdn.net/hongfengkt/article/details/48290561) 。


### PR DESCRIPTION
Add Tiercel to Swift.md under the networking section.

Tiercel is a pure Swift iOS download framework focused on background downloads, resumable transfers, relaunch recovery, and task management.